### PR TITLE
prepend EcomDev Autoloader on autoloader stack

### DIFF
--- a/src/app/code/community/EcomDev/ComposerAutoload/Model/Autoloader.php
+++ b/src/app/code/community/EcomDev/ComposerAutoload/Model/Autoloader.php
@@ -56,15 +56,15 @@ class EcomDev_ComposerAutoload_Model_Autoloader
      */
     public function register()
     {
-        if (in_array(array(Varien_Autoload::instance(), 'autoload'), spl_autoload_functions(), true)) {
-            spl_autoload_unregister(array(Varien_Autoload::instance(), 'autoload'));
-            spl_autoload_register(array($this, 'autoload'));
-        }
-        
         if ($autoloaderFile = $this->getAutoloadFilePath()) {
             include $autoloaderFile;
         }
-        
+
+        if (in_array(array(Varien_Autoload::instance(), 'autoload'), spl_autoload_functions(), true)) {
+            spl_autoload_unregister(array(Varien_Autoload::instance(), 'autoload'));
+            spl_autoload_register(array($this, 'autoload'), true, true);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
let composer first register its autoloader on top and register EcomDev Autoloader afterwards.
reason: Composer Autoloader tries to resolve Magento classes (which it can't) and only after this the Varien Autoloader jumps into action.
